### PR TITLE
docs: fix simple typo, warnnings -> warnings

### DIFF
--- a/plugin/plugin.cpp
+++ b/plugin/plugin.cpp
@@ -83,7 +83,7 @@ void on_finish_parse_function(void *gcc_data, void *user_data) {
 
 void on_all_passes_start(void *gcc_data, void *user_data) {
   /* Silence all "stack usage computation not supported for this target"
-   * warnnings. */
+   * warnings. */
   current_function_static_stack_size = 0;
 }
 


### PR DESCRIPTION
There is a small typo in plugin/plugin.cpp.

Should read `warnings` rather than `warnnings`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md